### PR TITLE
override $ENV{ALIEN_INSTALL_TYPE} = share on non-windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ jobs:
   include:
     - env: CIP_TAG=static
     - env: CIP_TAG=5.31
-    - env: CIP_TAG=5.30
+    - env: CIP_TAG=5.30 CIP_ENV=ALIEN_INSTALL_TYPE=share
+    - env: CIP_TAG=5.30 CIP_ENV=ALIEN_INSTALL_TYPE=system
     - env: CIP_TAG=5.28
     - env: CIP_TAG=5.26
     - env: CIP_TAG=5.24
@@ -29,7 +30,9 @@ jobs:
     - env: CIP_TAG=5.14
     - env: CIP_TAG=5.12
     - env: CIP_TAG=5.10
-    - env: CIP_TAG=5.8
+    - env: CIP_TAG=5.8 CIP_ENV=ALIEN_INSTALL_TYPE=share
+    - env: CIP_TAG=5.8 CIP_ENV=ALIEN_INSTALL_TYPE=system
+
 
 cache:
   directories:

--- a/alienfile
+++ b/alienfile
@@ -3,6 +3,10 @@ use Path::Tiny qw( path );
 use File::Glob qw( bsd_glob );
 use File::Which qw( which );
 
+#  no share install unless on windows
+delete $ENV{ALIEN_INSTALL_TYPE}
+  if $^O ne 'MSWin32' && $^O ne 'cygwin';
+
 if($^O eq 'MSWin32')
 {
   my $ver;

--- a/dist.ini
+++ b/dist.ini
@@ -44,12 +44,6 @@ ExtUtils::MakeMaker = 7.38
 [Prereqs / BuildRequires]
 ExtUtils::MakeMaker = 7.38
 
-[Prereqs / BuildRecommends]
-Win32::Shortcut = 0
-
-[Prereqs / RuntimeRecommends]
-Win32::Shortcut = 0
-
 [Author::Plicease::Upload]
 cpan = 1
 


### PR DESCRIPTION
PR to address #9.

The first commit does the work.

The second commit adds a macos workflow file to verify it works.  That fails due to prereqs that won't work under macos.  I don't know enough about distzilla to modify its ini file for this case.  

I can drop the workflow file from the PR if you don't think it's needed.  